### PR TITLE
Fix team selection return value

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,8 @@ def team_builder(
     Returns:
         ProductResponse: JSON payload with selected team.
     """
-    team, total_cost = select_team(products, budget)
+    team = select_team(products, budget)
     if len(team) < 5:
         raise HTTPException(status_code=400, detail="Not enough diverse products in budget")
-    return ProductResponse(products=team, total_cost=round(total_cost, 2))
+    total_cost = round(sum(p.price for p in team), 2)
+    return ProductResponse(products=team, total_cost=total_cost)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,7 +29,7 @@ def load_product_data():
 def team_builder(
         budget: float = Query(..., gt=0),
         products: List[Product] = Depends(get_products),
-):
+) -> ProductResponse:
     """GET endpoint to return a value-optimized team of products within a budget.
 
     Args:

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -23,10 +23,16 @@ def load_products(path: str = None) -> List[Product]:
 
 
 def select_team(products: List[Product], budget: float) -> List[Product]:
-    """Return the best combination of products within ``budget``.
+    """
+    Build an optimal mix of five products, one from each category, while
+    staying under the given budget. Scoring favors higher-rated items and
+    slightly rewards fuller budget usage.
+    Args:
+        products (List[Product]): A list of available product entries.
+        budget (float): The maximum total price for the team.
 
-    The algorithm selects 5 products from distinct categories using a weighted
-    score based on rating and budget utilisation.
+    Returns:
+        List[Product]
     """
 
     # Group all eligible products by category (only rating >= 4.0)

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -23,23 +23,17 @@ def load_products(path: str = None) -> List[Product]:
 
 
 def select_team(products: List[Product], budget: float) -> List[Product]:
-    """
-    Selects a team of 5 products from distinct categories that maximizes overall value
-    while staying within a given budget. The algorithm balances product rating and
-    total budget utilization to encourage thoughtful, cost-effective selection.
+    """Return the best combination of products within ``budget``.
 
-    Args:
-        products (List[Product]): A list of available product entries.
-        budget (float): The maximum total price for the team.
-
-    Returns:
-        Tuple(List[Product], float): A team of 5 products, each from a unique category and total price.
+    The algorithm selects 5 products from distinct categories using a weighted
+    score based on rating and budget utilisation.
     """
 
     # Group all eligible products by category (only rating >= 4.0)
     category_map = defaultdict(list)
     for p in products:
-        category_map[p.category].append(p)
+        if p.rating >= 4.0:
+            category_map[p.category].append(p)
 
     # For each category, keep only the top 3 highest-value products
     # to reduce memory usage and computation time
@@ -73,4 +67,4 @@ def select_team(products: List[Product], budget: float) -> List[Product]:
                 best_score = total_score
                 best_team = team  # store best team found so far
 
-    return list(best_team), sum(i.price for i in best_team)
+    return list(best_team)


### PR DESCRIPTION
## Summary
- make backend package importable
- filter products below rating 4
- `select_team` returns a list again
- update API to compute total cost separately

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876286210cc83328167b300d6f0036e