### PR TITLE
Update utils docstring and tests

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -24,16 +24,16 @@ def load_products(path: str = None) -> List[Product]:
 
 def select_team(products: List[Product], budget: float) -> List[Product]:
     """
-    Selects a team of 5 products from distinct categories that maximizes overall value
-    while staying within a given budget. The algorithm balances product rating and
-    total budget utilization to encourage thoughtful, cost-effective selection.
+    Build an optimal mix of five products, one from each category, while
+    staying under the given budget. Scoring favors higher-rated items and
+    slightly rewards fuller budget usage.
 
     Args:
         products (List[Product]): A list of available product entries.
         budget (float): The maximum total price for the team.
 
     Returns:
-        Tuple(List[Product], float): A team of 5 products, each from a unique category and total price.
+        Tuple(List[Product], float): The selected products and their total cost.
     """
 
     # Group all eligible products by category (only rating >= 4.0)

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -15,18 +15,17 @@ mock_products = [
 
 
 def test_select_team_returns_five_unique_categories():
-    team = select_team(mock_products, budget=300)
+    team, cost = select_team(mock_products, budget=300)
     assert len(team) == 5, "Team should have 5 products"
     assert len(set(p.category for p in team)) == 5, "Each product should have a unique category"
 
 
 def test_select_team_respects_budget():
-    team = select_team(mock_products, budget=250)
-    total_price = sum(p.price for p in team)
+    team, total_price = select_team(mock_products, budget=250)
     assert total_price <= 250, f"Total price {total_price} should be under budget"
 
 
 def test_select_team_empty_if_budget_too_low():
-    team = select_team(mock_products, budget=50)
+    team, cost = select_team(mock_products, budget=50)
     assert isinstance(team, list), "Should return a list"
     assert len(team) < 5, "Should return less than 5 if budget is insufficient"


### PR DESCRIPTION
## Summary
- improve `select_team` docstring with new description
- update tests to handle new tuple return structure

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876311d145c833291d61ca4a8649501